### PR TITLE
Changes libandroid-support-dev to ndk-sysroot

### DIFF
--- a/termux-makepkg
+++ b/termux-makepkg
@@ -82,7 +82,7 @@ declare -r -a MAKEPKG_DEPENDENCIES=(
     'gawk'
     'grep'
     'gzip'
-    'libandroid-support-dev'
+    'ndk-sysroot'
     'libtool'
     'lzip'
     'lzop'


### PR DESCRIPTION
libandroid-support-dev is deprecated, as we can see hère :
```
Package libandroid-support-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or     is only available from another source
However the following packages replace it:
  ndk-sysroot                                                         
E: Package 'libandroid-support-dev' has no installation candidate
```